### PR TITLE
Added support for Weight value on nodes

### DIFF
--- a/templates/slurm.conf
+++ b/templates/slurm.conf
@@ -73,7 +73,7 @@ include /etc/slurm-llnl/slurm-%c.conf
 
 # COMPUTE NODES 
 {% for node in nodes %}
-NodeName={{ node.hostname }} NodeAddr={{ node.ingress_address }} State=UNKNOWN Boards={{ node.inventory.Boards }} SocketsPerBoard={{ node.inventory.SocketsPerBoard }} CoresPerSocket={{ node.inventory.CoresPerSocket }} ThreadsPerCore={{ node.inventory.ThreadsPerCore }} RealMemory={{ node.inventory.RealMemory }}
+NodeName={{ node.hostname }} NodeAddr={{ node.ingress_address }} State=UNKNOWN Boards={{ node.inventory.Boards }} SocketsPerBoard={{ node.inventory.SocketsPerBoard }} CoresPerSocket={{ node.inventory.CoresPerSocket }} ThreadsPerCore={{ node.inventory.ThreadsPerCore }} RealMemory={{ node.inventory.RealMemory }} {% if node.inventory.Weight %}Weight={{ node.inventory.Weight }}{% endif %}
 {%- endfor -%}
 {% for partition, values in partitions.items() %}
 PartitionName={{ partition }} Nodes={{ values.hosts|join(',') }} Default={{ 'YES' if values.default else 'NO' }} State=UP


### PR DESCRIPTION
Modified the slurm.conf template to include the Weight parameter if the
slurm-controller charm has been instructed to put weight on nodes via
the node_weight_criteria charm option.

When it is preferable to allocate for example smaller memory nodes for
smaller jobs, low weights should be assigned to smaller nodes.
Configuring node_weight_criteria on the slurm-controller charm  will
automatically order and weigh the nodes in ascending order. Allowed
values are RealMemory, CPUs and CoresPerSocket.